### PR TITLE
Fix the IRC link href to point to #railscamp_de

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ title: RailsCamp Germany 2013
       add your name to something you want to be responsible for</li>
       <li>Get on the <a href="https://groups.google.com/forum/?fromgroups#!forum/railscamp2013">
         orga mailing list</a></li>
-      <li>Jump on the IRC channel: <a href="irc://irc.freenode.net:7000/5apps">
+      <li>Jump on the IRC channel: <a href="irc://irc.freenode.net:7000/railscamp_de">
         #railscamp_de on Freenode</a></li>
     </ul>
   </section>


### PR DESCRIPTION
It's currently pointing to #5apps
